### PR TITLE
Fix Deprecation Warning on nth function

### DIFF
--- a/src/sass/_responsiveness.scss
+++ b/src/sass/_responsiveness.scss
@@ -1,5 +1,6 @@
 @use "bulma/sass/utilities/mixins" as mxBulma;
 @use "./mixins" as mx;
+@use 'sass:list';
 
 [data-tooltip] {
 	@each $direction in top, right, bottom, left {
@@ -163,8 +164,8 @@
 
 	// Text alignment breakpoints
 	@each $direction in (left, left), (centered, center), (right, right) {
-		$dir: nth($direction, 1);
-		$text: nth($direction, 2);
+		$dir: list.nth($direction, 1);
+		$text: list.nth($direction, 2);
 
 		&.has-tooltip-text-#{$dir}-mobile {
 			@include mxBulma.mobile {


### PR DESCRIPTION
Fix Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0. Use list.nth instead.